### PR TITLE
Fix d435's auto exposure setting

### DIFF
--- a/realsense2_camera/cfg/base_d400_params.py
+++ b/realsense2_camera/cfg/base_d400_params.py
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 def add_base_params(gen, prefix):
   #             Name                                               Type    Level Description                  Default    Min     Max
   gen.add(str(prefix) + "depth_gain",                              int_t,    1,  "Gain",                      16,        16,     248)
-  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      True)
+  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      False)
   preset_enum = gen.enum([gen.const("Custom",        int_t,  0,  "Custom"),
                           gen.const("Default",       int_t,  1,  "Default Preset"),
                           gen.const("Hand",          int_t,  2,  "Hand Gesture"),

--- a/realsense2_camera/include/rs415_node.h
+++ b/realsense2_camera/include/rs415_node.h
@@ -9,7 +9,7 @@
 namespace realsense2_camera
 {
     enum rs415_param{
-        rs415_depth_enable_auto_white_balance = 9,
+        rs415_depth_enable_auto_white_balance = 20,
         rs415_depth_exposure,
         rs415_depth_laser_power,
         rs415_depth_emitter_enabled,

--- a/realsense2_camera/include/rs435_node.h
+++ b/realsense2_camera/include/rs435_node.h
@@ -9,7 +9,7 @@
 namespace realsense2_camera
 {
     enum rs435_param{
-        rs435_depth_exposure = 9,
+        rs435_depth_exposure = 20,
         rs435_depth_laser_power,
         rs435_depth_emitter_enabled,
         rs435_color_backlight_compensation,

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1471,7 +1471,7 @@ void BaseD400Node::setParam(base_d400_paramsConfig &config, base_depth_param par
         setOption(DEPTH, RS2_OPTION_ENABLE_AUTO_EXPOSURE, config.base_depth_enable_auto_exposure);
         break;
     case base_depth_visual_preset:
-        ROS_DEBUG_STREAM("base_depth_enable_auto_exposure: " << config.base_depth_visual_preset);
+        ROS_DEBUG_STREAM("base_depth_visual_preset: " << config.base_depth_visual_preset);
         setOption(DEPTH, RS2_OPTION_VISUAL_PRESET, config.base_depth_visual_preset);
         break;
     case base_depth_frames_queue_size:
@@ -1483,7 +1483,7 @@ void BaseD400Node::setParam(base_d400_paramsConfig &config, base_depth_param par
         setOption(DEPTH, RS2_OPTION_ERROR_POLLING_ENABLED, config.base_depth_error_polling_enabled);
         break;
     case base_depth_output_trigger_enabled:
-        ROS_DEBUG_STREAM("base_depth_error_polling_enabled: " << config.base_depth_output_trigger_enabled);
+        ROS_DEBUG_STREAM("base_depth_output_trigger_enabled: " << config.base_depth_output_trigger_enabled);
         setOption(DEPTH, RS2_OPTION_OUTPUT_TRIGGER_ENABLED, config.base_depth_output_trigger_enabled);
         break;
     case base_depth_units:


### PR DESCRIPTION
In this PR, I included the following fixes:

- Fix for mistakes in rs4xx_param enum definition that may have caused issues when using dynamic reconfigure to configure the auto exposure setting

- Setting the auto exposure setting to false by default in dynamic reconfigure server to reflect the actual hardware behaviour from observation