### PR TITLE
Update for librealsense 2.36 compatibility

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1667,7 +1667,7 @@ void BaseD400Node::registerDynamicReconfigCb()
 /**
 Constructor for filter_options, takes a name and a filter.
 */
-filter_options::filter_options(const std::string name, rs2::process_interface& filter) :
+filter_options::filter_options(const std::string name, rs2::filter& filter) :
     filter_name(name),
     filter(filter),
     is_enabled(true) {}


### PR DESCRIPTION
* Updated references to rs2::processing_interface to reflect changes to
  librealsense API changes. See
  https://github.com/IntelRealSense/librealsense/wiki/API-Changes#from-version-2160-to-2170
  for more information.

* Added rs2::asynchronous_syncer shim since the class no longer receives
  an inherited operator() from rs2::processing_block. See
  https://github.com/IntelRealSense/librealsense/wiki/API-Changes#from-version-2150-to-2160
  for more information.