### PR TITLE
Add 'json_config' service endpoint to realsense2_camera node.

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -52,6 +52,11 @@ add_message_files(
     Extrinsics.msg
     )
 
+add_service_files(
+    FILES
+    JsonConfig.srv
+)
+
 generate_messages(
     DEPENDENCIES
     sensor_msgs

--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -132,6 +132,11 @@ install(DIRECTORY launch/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
     )
 
+# Install scripts
+install(DIRECTORY scripts/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/scripts
+    )
+
 # Install rviz files
 install(DIRECTORY rviz/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -8,7 +8,7 @@
 #include <realsense2_camera/base_d400_paramsConfig.h>
 #include <realsense2_camera/rs415_paramsConfig.h>
 #include <realsense2_camera/rs435_paramsConfig.h>
-
+#include <realsense2_camera/JsonConfig.h>
 #include <std_srvs/SetBool.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/update_functions.h>
@@ -121,6 +121,7 @@ namespace realsense2_camera
         static std::string getNamespaceStr();
         void getParameters();
         bool enableStreams(std_srvs::SetBool::Request  &req, std_srvs::SetBool::Response &res);
+        bool JsonConfigCallback(JsonConfig::RequestType &request, realsense2_camera::JsonConfig::ResponseType &response);
         void setupDevice();
         void setupPublishers();
         void setupServices();
@@ -202,6 +203,7 @@ namespace realsense2_camera
         ros::Publisher _pointcloud_xyz_publisher;
         ros::Publisher _pointcloud_xyzrgb_publisher;
         ros::ServiceServer _enable_streams_service;
+        ros::ServiceServer _json_config_service;
         ros::Time _ros_time_base;
         bool _align_depth;
         bool _sync_frames;

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>realsense2_camera</name>
-  <version>2.0.8</version>
+  <version>2.0.9</version>
   <description>RealSense Camera package allowing access to Intel 3D D400 cameras</description>
   <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>
   <maintainer email="itay.carpis@intel.com">Itay Carpis</maintainer>

--- a/realsense2_camera/scripts/rs2_json_config.py
+++ b/realsense2_camera/scripts/rs2_json_config.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python2
+
+# rs2_json_config.py - A simple script to allow changing of 
+# realsense2_camera parameters on the command line. 
+# 
+# This script was written because the 'rosservice' command 
+# parses arguments using the YAML parser, so inputting a JSON configuration 
+# string is non-trivial. 
+# 
+# Author: Paul Belanger
+# Date: 2020-08-06
+
+# This script adapted from the ROS python service client tutorial: 
+# http://wiki.ros.org/ROS/Tutorials/WritingServiceClient%28python%29
+
+from __future__ import print_function
+
+import sys
+import rospy
+from realsense2_camera.srv import * 
+
+
+def json_config_client(ns, new_config_json): 
+    """
+    Calls the json_config service, passing the new json configuration. 
+
+    :param ns: The namespace of the node to modify, without the
+               'realsense2_camera/json_config' suffix.  This usually 
+               corresponds to the 'ns' argument passed when starting a
+               realsense2_camera node. 
+
+    :param new_config_json: A JSON string containing the new configuration to
+                            apply. May be an empty string to obtain the 
+                            current configuration. 
+
+    :return: A string containing the current configuration of the
+             realsense2_camera node. 
+    """
+
+    service_name = ns + "/realsense2_camera/json_config"
+    rospy.wait_for_service(service_name)
+
+    try:
+        proxy = rospy.ServiceProxy(service_name, JsonConfig)
+        result = proxy(new_config_json)
+        return result.new_config
+
+    except rospy.ServiceException as e:
+        print("Service Call Failed: {}".format(e))
+
+if(__name__ == "__main__"):
+    if len(sys.argv) == 3:
+        ns = sys.argv[1]
+        new_config = sys.argv[2]
+
+        result = json_config_client(ns, new_config)
+        print(result)
+
+    elif len(sys.argv) == 2:
+        ns = sys.argv[1]
+
+        result = json_config_client(ns, "")
+        print(result)
+
+    else:
+        print("usage: {} <camera ns> [new json config string] ")
+        sys.exit(1);
+
+

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1,5 +1,8 @@
 #include "../include/base_realsense_node.h"
 #include "../include/sr300_node.h"
+#include <librealsense2/hpp/rs_serializable_device.hpp>
+#include <realsense2_camera/JsonConfigRequest.h>
+#include <realsense2_camera/JsonConfigResponse.h>
 
 using namespace realsense2_camera;
 
@@ -154,6 +157,33 @@ bool BaseRealSenseNode::enableStreams(std_srvs::SetBool::Request& req, std_srvs:
     }
 
     return true;
+}
+
+bool BaseRealSenseNode::JsonConfigCallback(JsonConfig::RequestType &request, JsonConfig::ResponseType &response)
+{
+    // obviously this only works if the device supports serialilzation in the first place...
+    if(not _dev.is<rs2::serializable_device>())
+    {
+        ROS_ERROR("json_config service called but we are not a serializable device! ");
+        return false;
+    }
+
+    // the internal realsense parser fails on an empty string, so we give it an empty object to parse.
+    if(request.json_string.empty()) request.json_string = "{}";
+
+    try
+    {
+        auto ser_dev = _dev.as<rs2::serializable_device>();
+
+        ser_dev.load_json(request.json_string);
+        response.new_config = ser_dev.serialize_json();
+        return true;
+    }
+    catch (const std::exception& ex)
+    {
+        ROS_ERROR_STREAM("Error on JsonConfigCallback: " << ex.what());
+        return false;
+    }
 }
 
 void BaseRealSenseNode::getParameters()
@@ -365,6 +395,7 @@ void BaseRealSenseNode::setupServices()
 {
   ROS_INFO("setupServices...");
   _enable_streams_service = _pnh.advertiseService("enable_streams", &BaseRealSenseNode::enableStreams, this);
+  _json_config_service = _pnh.advertiseService("json_config", &BaseRealSenseNode::JsonConfigCallback, this);
 }
 
 void BaseRealSenseNode::setupPublishers()

--- a/realsense2_camera/srv/JsonConfig.srv
+++ b/realsense2_camera/srv/JsonConfig.srv
@@ -1,0 +1,6 @@
+# The Json configuraiton string, containing entries for the values that are to be modified.
+# note that the current configuration can be obtained (without modifications) by passing the empty string.
+string json_string
+---
+# The new whole configuration of the realsense camera.
+string new_config


### PR DESCRIPTION
* The service takes a JSON string containing properties that are
  to be changed, and returns the entire new configuration

* An empty string may be passed to obtain the current configuration
  without modifying any parameters.

* It seems that it takes  a non-trivial amount of time to apply the JSON
  settings (1-2 seconds). Further investigation would be needed to
  identify the source of the slowdown.