### PR TITLE
SEN-793: Add fix_set_exposure functionality to realsense node

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(${PROJECT_NAME}
     src/realsense_nodelet.cpp
     src/realsense_node.cpp
     src/param_manager.cpp
+    src/fix_set_exposure.cpp
     )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -93,6 +93,11 @@ namespace realsense2_camera
     const std::string DEFAULT_ALIGNED_DEPTH_TO_INFRA2_FRAME_ID = "camera_aligned_depth_to_infra2_frame";
     const std::string DEFAULT_ALIGNED_DEPTH_TO_FISHEYE_FRAME_ID = "camera_aligned_depth_to_fisheye_frame";
 
+    const bool DEFAULT_USE_FIX_SET_EXPOSURE = true;
+    const int DEFAULT_FIX_SET_EXPOSURE_MAX_TRIES = 5;
+    const double DEFAULT_FIX_SET_EXPOSURE_MAX_RESET_WAIT = 5.0; // [s]
+    const double DEFAULT_FIX_SET_EXPOSURE_MAX_FAIL_WAIT = 1.0; // [s]
+
     using stream_index_pair = std::pair<rs2_stream, int>;
 }  // namespace realsense2_camera
 

--- a/realsense2_camera/include/realsense2_camera/fix_set_exposure.h
+++ b/realsense2_camera/include/realsense2_camera/fix_set_exposure.h
@@ -1,0 +1,55 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ */
+/**
+ * @license Apache 2.0. See LICENSE file in root directory.
+ * @copyright Copyright 2020, Avidbots Corp.
+ * @file      fix_set_autoexposure.h
+ * @brief     Header for fix_set_autoexposure.cpp, A utility to automatically
+ * hardware-reset the camera until the auto-exposure setting works.
+ * @author  Paul Belanger
+ */
+
+#ifndef REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H
+#define REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H
+
+#include <librealsense2/rs.hpp>
+#include <ros/duration.h>
+
+namespace realsense2_camera
+{
+
+/**
+ * @brief Fix the autoexposure setting for the given rs2 device.
+ *
+ * This function
+ * attempts to modify the depth_autoexposure setting on the device. If that fails,
+ * the device is issued a hardware reset command and the setting is tried again.
+ * This continues until the device begins working properly or the max number of
+ * retries is reached.
+ *
+ * @param context The context that was used to create the device.
+ * @param device The device to test. Note: the underlying device pointer may change
+ * during the execution of this function.
+ * @param reset_wait_duration The amount of time to wait between issuing a
+ * hardware reset and attempting to re-probe the device.
+ * @param max_resets The maximum number of hardware resets to attempt.
+ * @param fail_wait_duration If setting of the ae param fails, we wait this amount
+ * of time before trying a second time, and then fall back to the hardware reset
+ * if a second attempt fails.
+ * @return True if the device was successfully reset. False if the max number of
+ * resets has been attempted but the device still isn't responding.
+ *
+ * @note This function always unconditionally performs at least one hardware_reset()
+ * of the camera.
+ */
+bool fixSetExposure(rs2::context& context, rs2::device& device, ros::Duration reset_wait_duration, int max_resets, ros::Duration fail_wait_duration);
+
+} // namespace realsense2_camera
+#endif // REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H

--- a/realsense2_camera/include/realsense2_camera/realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/realsense_node.h
@@ -250,6 +250,11 @@ class RealSenseParamManager;
         ros::Duration depth_callback_timeout_;
         std::unique_ptr<RealSenseParamManagerBase> _params;
 
+        bool _use_fix_set_exposure;
+        int _fix_set_exposure_max_tries;
+        double _fix_set_exposure_max_reset_wait; // [s]
+        double _fix_set_exposure_max_fail_wait; // [s]
+
         const std::vector<std::vector<stream_index_pair>> IMAGE_STREAMS = {{{DEPTH, INFRA1, INFRA2},
                                                                             {COLOR},
                                                                             {FISHEYE}}};

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -45,6 +45,11 @@
   <arg name="enable_ros_time"     default="false"/>
   <arg name="align_depth"         default="false"/>
 
+  <arg name="use_fix_set_exposure" default="false"/>
+  <arg name="fix_set_exposure_max_tries" default="5"/>
+  <arg name="fix_set_exposure_max_reset_wait" default="5"/>
+  <arg name="fix_set_exposure_max_fail_wait" default="1"/>
+
   <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
   <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
@@ -97,6 +102,11 @@
     <param name="aligned_depth_to_infra1_frame_id"  type="str"  value="camera_aligned_depth_to_infra1_frame"/>
     <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
     <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
+
+    <param name="use_fix_set_exposure" type="bool" value="$(arg use_fix_set_exposure)"/>
+    <param name="fix_set_exposure_max_tries" type="int" value="$(arg fix_set_exposure_max_tries)"/>
+    <param name="fix_set_exposure_max_reset_wait" type="double" value="$(arg fix_set_exposure_max_reset_wait)"/>
+    <param name="fix_set_exposure_max_fail_wait" type="double" value="$(arg fix_set_exposure_max_fail_wait)"/>
   </node>
 </launch>
 

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -37,6 +37,11 @@
   <arg name="enable_ros_time"     default="false"/>
   <arg name="align_depth"         default="false"/>
 
+  <arg name="use_fix_set_exposure" default="false"/>
+  <arg name="fix_set_exposure_max_tries" default="5"/>
+  <arg name="fix_set_exposure_max_reset_wait" default="5"/>
+  <arg name="fix_set_exposure_max_fail_wait" default="1"/>
+
   <group ns="$(arg camera)">
     <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
       <arg name="serial_no"                value="$(arg serial_no)"/>
@@ -75,6 +80,11 @@
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_imu"               value="$(arg enable_imu)"/>
+
+      <arg name="use_fix_set_exposure" value="$(arg use_fix_set_exposure)"/>
+      <arg name="fix_set_exposure_max_tries" value="$(arg fix_set_exposure_max_tries)"/>
+      <arg name="fix_set_exposure_max_reset_wait" value="$(arg fix_set_exposure_max_reset_wait)"/>
+      <arg name="fix_set_exposure_max_fail_wait" value="$(arg fix_set_exposure_max_fail_wait)"/>
     </include>
   </group>
 </launch>

--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>realsense2_camera</name>
-  <version>2.0.13</version>
+  <version>2.1.0</version>
   <description>RealSense Camera package allowing access to Intel 3D D400 cameras</description>
   <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>
   <maintainer email="itay.carpis@intel.com">Itay Carpis</maintainer>

--- a/realsense2_camera/src/fix_set_exposure.cpp
+++ b/realsense2_camera/src/fix_set_exposure.cpp
@@ -1,0 +1,189 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ */
+/**
+ * @license Apache 2.0. See LICENSE file in root directory.
+ * @copyright Copyright 2020, Avidbots Corp.
+ * @file      fix_set_autoexposure.cpp
+ * @brief     Brief description of file.
+ * @author    Paul Belanger
+ */
+
+// most of this code is adapted from the fix_set_autoexposure script in the
+// avidbots robot repo.
+
+#include <realsense2_camera/fix_set_exposure.h>
+#include <ros/console.h>
+#include <boost/interprocess/sync/named_mutex.hpp>
+
+namespace realsense2_camera
+{
+
+
+
+// through experimentation, it takes the D435 sensor about 2 seconds to
+// finish its hardware reset.
+// unfortunately there isn't a way to know for sure that a device has finished resetting.
+// if we wait for less than this time, then we'll end up picking up the original
+// sensor before it finishes disconnecting from the USB bus, leading to all sorts of
+// issues down the line when we try to pull frames.
+const static double MIN_REACQUIRE_WAIT_TIME = 2.5; //[s]
+
+/**
+ * @brief Attempt to toggle the autoexposure value of the device.
+ * @param device  The device to operate on
+ * @return  True if the setting was applied successfully, otherwise false.
+ */
+static bool try_set_autoexposure(rs2::device& device)
+{
+  const auto option = rs2_option::RS2_OPTION_ENABLE_AUTO_EXPOSURE;
+
+  rs2::sensor stereo_module;
+  bool depth_sensor_found = false;
+  for(auto& sen: device.query_sensors())
+  {
+    if(sen.is<rs2::depth_sensor>())
+    {
+      depth_sensor_found = true;
+      stereo_module = sen;
+    }
+  }
+  if(! depth_sensor_found)
+  {
+    ROS_ERROR("Could not find a depth sensor on the device! ");
+    return false;
+  }
+
+  try
+  {
+    const float original_value = stereo_module.get_option(option);
+    const float expected_new_value = (original_value > 0.0f ? 0.0f : 1.0f);
+    ROS_DEBUG_STREAM("Set autoexposure " << original_value << " -> " << expected_new_value);
+    stereo_module.set_option(option, expected_new_value);
+    const float actual_new_value = stereo_module.get_option(option);
+    ROS_DEBUG_STREAM("Actual autoexposure value: " << actual_new_value);
+    return (actual_new_value == expected_new_value);
+  }
+  catch(const rs2::error& ex)
+  {
+    ROS_WARN_STREAM("try_set_autoexposure failed: " << ex.what());
+    return false;
+  }
+}
+
+/**
+ * @brief Tries to set autoexposure. If it fails, wait the specified duration and try again.
+ * @param device device to operate on
+ * @param fail_wait_duration Amount to wait if the first setting fails.
+ * @return True if the setting finally succeeds, otherwise false.
+ */
+static bool try_set_autoexposure_twice(rs2::device& device, ros::Duration fail_wait_duration)
+{
+  if(try_set_autoexposure(device))
+  {
+    return true;
+  }
+  else
+  {
+    fail_wait_duration.sleep();
+    return try_set_autoexposure(device);
+  }
+}
+
+/**
+ * @brief Attempt to reacquire a device with a given serial number.
+ * @param context The context used to query devices.
+ * @param serial The serial of the device to find.
+ * @param[out] out_device Pointer to the device will be placed here.
+ * @param max_wait_duration The maximum amount of time to wait for the device
+ * to come online.
+ * @return
+ */
+static bool reacquire_device(rs2::context& context, const std::string& serial, rs2::device& out_device, ros::Duration max_wait_duration)
+{
+  ros::Duration amount_waited_so_far(0.0);
+
+  try
+  {
+    while(amount_waited_so_far < max_wait_duration)
+    {
+      // we always sleep first to allow the device time to drop off the bus so
+      // we don't accidentally acquire the disconnecting device.
+      auto sleep_time = std::min(ros::Duration(MIN_REACQUIRE_WAIT_TIME), max_wait_duration - amount_waited_so_far);
+      amount_waited_so_far += sleep_time;
+      sleep_time.sleep();
+
+      namespace bi = boost::interprocess;
+      bi::named_mutex usb_mutex{bi::open_or_create, "usb_mutex"};
+      usb_mutex.lock();
+      auto devlist = context.query_devices();
+      usb_mutex.unlock();
+
+      for(auto dev: devlist)
+      {
+        std::string dev_serial = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+        if(dev_serial == serial)
+        {
+          out_device = dev;
+          return true;
+        }
+      }
+      // no device with matching serial found. Try again after a short delay.
+    }
+  }
+  catch(const rs2::error& e)
+  {
+    ROS_FATAL_STREAM("Error when enumerating devices: " << e.what());
+  }
+  // no device found after waiting the max duration.
+  return false;
+}
+
+bool fixSetExposure(rs2::context& context, rs2::device &device, ros::Duration reset_wait_duration,
+                        int max_resets, ros::Duration fail_wait_duration)
+{
+  // since the hardware_reset causes the device to re-enumerate on the USB
+  // bus, we need to track it by its unique serial number across resets.
+  std::string serial = device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+
+  for(int i = 0; i < max_resets; i++)
+  {
+    // changing the setting failed, so reset the hardware and try again.
+    ROS_INFO("Resetting device...");
+    try
+    {
+      device.hardware_reset();
+    }
+    catch(const rs2::error& ex)
+    {
+      ROS_FATAL_STREAM("hardware reset of device " << serial << " failed! ");
+      return false;
+    }
+    ROS_INFO("Reacquiring...");
+    if( ! reacquire_device(context, serial, device, reset_wait_duration))
+    {
+      // device couldn't be reacquired.
+      ROS_FATAL_STREAM("Could not reacquire device " << serial << "after a hardware reset! ");
+      return false;
+    }
+
+    ROS_INFO("Reacquired! ");
+
+    if(try_set_autoexposure_twice(device, fail_wait_duration))
+    {
+      // success!
+      return true;
+    }
+  }
+
+  ROS_FATAL_STREAM("Device " << serial << " did not respond after " << max_resets << "attempts! ");
+  return false;
+}
+
+} // namespace realsense2_camera


### PR DESCRIPTION
Functionality of the fix_set_exposure script from avidbots_camera_launch has
been integrated into the realsense driver node.

Through testing on my local machine, I also found that in some situations the
parameter setting would succeed the second time around after (I assume) the
hardware has finished initializing. Therefore, in the parameter set/read check,
if the first write/read fails, a second write/read is attempted after a short
amount of time. If this second attempt also fails then the device is commanded
perform its hardware reset.

The following new params were added (see rs_camera.launch) to control this
functionality:

  use_fix_set_exposure: bool (default: false) - Enable/disable the
		fix_set_exposure functionality. Defaults to false in order to remain
		backwards-compatible behaviour with versions of avidbots autonomy that still
		use the standalone fix_set_exposure script.

	fix_set_exposure_max_tries: int (default: 5) - Max number of times to try
		resetting the camera before giving up

	fix_set_exposure_max_reset_wait: double (default: 5.0) - Max amount of time
		to wait for the device to come back online after hardware reset, in seconds.

	fix_set_exposure_max_fail_wait: double (default: 1.0) - Max amount of time to
		wait between first and second attempt of setting auto exposure, in seconds.

Package version was also updated 2.0.13 -> 2.1.0