### PR TITLE
Fix initialization order for _unit_step_size

### DIFF
--- a/realsense2_camera/src/realsense_node.cpp
+++ b/realsense2_camera/src/realsense_node.cpp
@@ -28,9 +28,6 @@ RealSenseNode::RealSenseNode(const ros::NodeHandle &nodeHandle,
     _intialize_time_base(false),
     _namespace(getNamespaceStr())
 {
-     getParameters();
-     getDevice();
-
     // Types for depth stream
     _is_frame_arrived[DEPTH] = false;
     _format[DEPTH] = RS2_FORMAT_Z16;   // libRS type
@@ -90,6 +87,9 @@ RealSenseNode::RealSenseNode(const ros::NodeHandle &nodeHandle,
     _encoding[ACCEL] = sensor_msgs::image_encodings::TYPE_8UC1; // ROS message type
     _unit_step_size[ACCEL] = sizeof(uint8_t); // sensor_msgs::ImagePtr row step size
     _stream_name[ACCEL] = "accel";
+
+    getParameters();
+    getDevice();
 
     // TODO: Improve the pipeline to accept decimation filter
     // TODO: Provide disparity map if requested


### PR DESCRIPTION
This PR is to fix segmentation fault that occures when `align_depth` is enabled and we subscribe to one of the `camera/aligned_depth_to_*` topics.
The issue was that the `_unit_step_size` was not initialized before `getParameters()` call, but inside `getParameters` it is used when calculating `_aligned_depth_images` vectors size:
https://github.com/avidbots/realsense/blob/f26dbde4b8ddb832fe92621c10ddce709c6fa3f6/realsense2_camera/src/realsense_node.cpp#L286

So all the vectors inside `_aligned_depth_images` had size of 0 and because of that later on `data()` returned `nullptr` and we had segfault when trying to call memset with a null pointer

https://github.com/avidbots/realsense/blob/f26dbde4b8ddb832fe92621c10ddce709c6fa3f6/realsense2_camera/src/realsense_node.cpp#L677-L680

https://github.com/avidbots/realsense/blob/f26dbde4b8ddb832fe92621c10ddce709c6fa3f6/realsense2_camera/src/realsense_node.cpp#L596-L599