### PR TITLE
Sen 761 fixes for new realsense driver

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -86,7 +86,7 @@ add_library(${PROJECT_NAME}
     src/realsense_nodelet.cpp
     src/realsense_node.cpp
     src/param_manager.cpp
-    src/fix_set_exposure.cpp
+    src/fix_set_auto_exposure.cpp
     )
 
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)

--- a/realsense2_camera/cfg/base_d400_params.py
+++ b/realsense2_camera/cfg/base_d400_params.py
@@ -6,7 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 def add_base_params(gen, prefix):
   #             Name                                               Type    Level Description                  Default    Min     Max
   gen.add(str(prefix) + "depth_gain",                              int_t,    1,  "Gain",                      16,        16,     248)
-  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      False)
+  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      True)
   preset_enum = gen.enum([gen.const("Custom",        int_t,  0,  "Custom"),
                           gen.const("Default",       int_t,  1,  "Default Preset"),
                           gen.const("Hand",          int_t,  2,  "Hand Gesture"),

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -94,6 +94,7 @@ namespace realsense2_camera
     const std::string DEFAULT_ALIGNED_DEPTH_TO_FISHEYE_FRAME_ID = "camera_aligned_depth_to_fisheye_frame";
 
     const bool DEFAULT_USE_FIX_SET_EXPOSURE = true;
+    const bool DEFAULT_AUTO_EXPOSURE_SETTING = true;
     const int DEFAULT_FIX_SET_EXPOSURE_MAX_TRIES = 5;
     const double DEFAULT_FIX_SET_EXPOSURE_MAX_RESET_WAIT = 5.0; // [s]
     const double DEFAULT_FIX_SET_EXPOSURE_MAX_FAIL_WAIT = 1.0; // [s]

--- a/realsense2_camera/include/realsense2_camera/constants.h
+++ b/realsense2_camera/include/realsense2_camera/constants.h
@@ -93,7 +93,7 @@ namespace realsense2_camera
     const std::string DEFAULT_ALIGNED_DEPTH_TO_INFRA2_FRAME_ID = "camera_aligned_depth_to_infra2_frame";
     const std::string DEFAULT_ALIGNED_DEPTH_TO_FISHEYE_FRAME_ID = "camera_aligned_depth_to_fisheye_frame";
 
-    const bool DEFAULT_USE_FIX_SET_EXPOSURE = true;
+    const bool DEFAULT_USE_FIX_SET_EXPOSURE = false;  // To match ROS launch script
     const bool DEFAULT_AUTO_EXPOSURE_SETTING = true;
     const int DEFAULT_FIX_SET_EXPOSURE_MAX_TRIES = 5;
     const double DEFAULT_FIX_SET_EXPOSURE_MAX_RESET_WAIT = 5.0; // [s]

--- a/realsense2_camera/include/realsense2_camera/fix_set_auto_exposure.h
+++ b/realsense2_camera/include/realsense2_camera/fix_set_auto_exposure.h
@@ -10,14 +10,14 @@
 /**
  * @license Apache 2.0. See LICENSE file in root directory.
  * @copyright Copyright 2020, Avidbots Corp.
- * @file      fix_set_autoexposure.h
+ * @file      fix_set_auto_exposure.h
  * @brief     Header for fix_set_autoexposure.cpp, A utility to automatically
  * hardware-reset the camera until the auto-exposure setting works.
  * @author  Paul Belanger
  */
 
-#ifndef REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H
-#define REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H
+#ifndef REALSENSE2_CAMERA_FIX_SET_AUTO_EXPOSURE_H
+#define REALSENSE2_CAMERA_FIX_SET_AUTO_EXPOSURE_H
 
 #include <librealsense2/rs.hpp>
 #include <ros/duration.h>
@@ -49,7 +49,8 @@ namespace realsense2_camera
  * @note This function always unconditionally performs at least one hardware_reset()
  * of the camera.
  */
-bool fixSetExposure(rs2::context& context, rs2::device& device, ros::Duration reset_wait_duration, int max_resets, ros::Duration fail_wait_duration);
+bool fixSetAutoExposure(rs2::context& context, rs2::device& device, ros::Duration reset_wait_duration, int max_resets,
+                       ros::Duration fail_wait_duration, bool exposure);
 
 } // namespace realsense2_camera
-#endif // REALSENSE2_CAMERA_FIX_SET_EXPOSURE_H
+#endif // REALSENSE2_CAMERA_FIX_SET_AUTO_EXPOSURE_H

--- a/realsense2_camera/include/realsense2_camera/realsense_node.h
+++ b/realsense2_camera/include/realsense2_camera/realsense_node.h
@@ -264,7 +264,8 @@ class RealSenseParamManager;
         ros::Duration depth_callback_timeout_;
         std::unique_ptr<RealSenseParamManagerBase> _params;
 
-        bool _use_fix_set_exposure;
+        bool _use_fix_set_auto_exposure;
+        bool _auto_exposure_setting;
         int _fix_set_exposure_max_tries;
         double _fix_set_exposure_max_reset_wait; // [s]
         double _fix_set_exposure_max_fail_wait; // [s]

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -45,7 +45,8 @@
   <arg name="enable_ros_time"     default="false"/>
   <arg name="align_depth"         default="false"/>
 
-  <arg name="use_fix_set_exposure" default="false"/>
+  <arg name="use_fix_set_auto_exposure" default="false"/>
+  <arg name="auto_exposure_setting" default="true"/>
   <arg name="fix_set_exposure_max_tries" default="5"/>
   <arg name="fix_set_exposure_max_reset_wait" default="5"/>
   <arg name="fix_set_exposure_max_fail_wait" default="1"/>
@@ -103,7 +104,8 @@
     <param name="aligned_depth_to_infra2_frame_id"  type="str"  value="camera_aligned_depth_to_infra2_frame"/>
     <param name="aligned_depth_to_fisheye_frame_id" type="str"  value="camera_aligned_depth_to_fisheye_frame"/>
 
-    <param name="use_fix_set_exposure" type="bool" value="$(arg use_fix_set_exposure)"/>
+    <param name="use_fix_set_auto_exposure" value="$(arg use_fix_set_auto_exposure)"/>
+    <param name="auto_exposure_setting"     value="$(arg auto_exposure_setting)"/>
     <param name="fix_set_exposure_max_tries" type="int" value="$(arg fix_set_exposure_max_tries)"/>
     <param name="fix_set_exposure_max_reset_wait" type="double" value="$(arg fix_set_exposure_max_reset_wait)"/>
     <param name="fix_set_exposure_max_fail_wait" type="double" value="$(arg fix_set_exposure_max_fail_wait)"/>

--- a/realsense2_camera/launch/rs_camera.launch
+++ b/realsense2_camera/launch/rs_camera.launch
@@ -37,7 +37,8 @@
   <arg name="enable_ros_time"     default="false"/>
   <arg name="align_depth"         default="false"/>
 
-  <arg name="use_fix_set_exposure" default="false"/>
+  <arg name="use_fix_set_auto_exposure" default="false"/>
+  <arg name="auto_exposure_setting" default="true"/>
   <arg name="fix_set_exposure_max_tries" default="5"/>
   <arg name="fix_set_exposure_max_reset_wait" default="5"/>
   <arg name="fix_set_exposure_max_fail_wait" default="1"/>
@@ -81,7 +82,8 @@
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_imu"               value="$(arg enable_imu)"/>
 
-      <arg name="use_fix_set_exposure" value="$(arg use_fix_set_exposure)"/>
+      <arg name="use_fix_set_auto_exposure" value="$(arg use_fix_set_auto_exposure)"/>
+      <arg name="auto_exposure_setting"     value="$(arg auto_exposure_setting)"/>
       <arg name="fix_set_exposure_max_tries" value="$(arg fix_set_exposure_max_tries)"/>
       <arg name="fix_set_exposure_max_reset_wait" value="$(arg fix_set_exposure_max_reset_wait)"/>
       <arg name="fix_set_exposure_max_fail_wait" value="$(arg fix_set_exposure_max_fail_wait)"/>

--- a/realsense2_camera/src/fix_set_auto_exposure.cpp
+++ b/realsense2_camera/src/fix_set_auto_exposure.cpp
@@ -38,6 +38,7 @@ const static double MIN_REACQUIRE_WAIT_TIME = 2.5; //[s]
 /**
  * @brief Attempt to toggle the autoexposure value of the device.
  * @param device  The device to operate on
+ * @param exposure A flag to enable or disable auto exposure. Enabled if true.
  * @return  True if the setting was applied successfully, otherwise false.
  */
 static bool try_set_auto_exposure(rs2::device& device, bool exposure)
@@ -81,6 +82,7 @@ static bool try_set_auto_exposure(rs2::device& device, bool exposure)
  * @brief Tries to set autoexposure. If it fails, wait the specified duration and try again.
  * @param device device to operate on
  * @param fail_wait_duration Amount to wait if the first setting fails.
+ * @param exposure A flag to enable or disable auto exposure. Enabled if true.
  * @return True if the setting finally succeeds, otherwise false.
  */
 static bool try_set_auto_exposure_twice(rs2::device& device, ros::Duration fail_wait_duration, bool exposure)
@@ -103,7 +105,7 @@ static bool try_set_auto_exposure_twice(rs2::device& device, ros::Duration fail_
  * @param[out] out_device Pointer to the device will be placed here.
  * @param max_wait_duration The maximum amount of time to wait for the device
  * to come online.
- * @return
+ * @return True if succcesful
  */
 static bool reacquire_device(rs2::context& context, const std::string& serial, rs2::device& out_device, ros::Duration max_wait_duration)
 {
@@ -145,6 +147,16 @@ static bool reacquire_device(rs2::context& context, const std::string& serial, r
   return false;
 }
 
+/**
+ * @brief Attempt to fix auto exposure setting by reset hardware and checking the actual configuration on devices.
+ * @param context The context used to query devices.
+ * @param serial The serial of the device to find.
+ * @param reset_wait_duration Time to wait after reset for the device to come back online.
+ * @param max_resets The maximum number of times to try resetting a device.
+ * @param fail_wait_duration Time to wait before another attempt to try fixing auto exposure setting.
+ * @param exposure Auto exposure setting value to be set on the device. Enabled if true.
+ * @return True if succcesful.
+ */
 bool fixSetAutoExposure(rs2::context& context, rs2::device &device, ros::Duration reset_wait_duration,
                         int max_resets, ros::Duration fail_wait_duration, bool exposure)
 {

--- a/realsense2_camera/src/realsense_node.cpp
+++ b/realsense2_camera/src/realsense_node.cpp
@@ -1103,6 +1103,17 @@ void RealSenseNode::setupStreams()
             ex.translation[0] *= -1;
             ex.translation[1] *= -1;
             ex.translation[2] *= -1;
+
+            // Invert rotation matrix by transposing
+            // According to Intel's documentation rotation of struct rs2_extrinsics is a column-major matrix
+            // so columns become rows like below:
+            // 0 3 6     0 1 2
+            // 1 4 7  -> 3 4 5
+            // 2 5 8     6 7 8
+            std::swap(ex.rotation[1], ex.rotation[3]);
+            std::swap(ex.rotation[2], ex.rotation[6]);
+            std::swap(ex.rotation[5], ex.rotation[7]);
+
             _depth_to_other_extrinsics[INFRA2] = ex;
             _depth_to_other_extrinsics_publishers[INFRA2].publish(rsExtrinsicsToMsg(ex, frame_id));
         }

--- a/realsense2_camera/src/realsense_node.cpp
+++ b/realsense2_camera/src/realsense_node.cpp
@@ -212,7 +212,7 @@ void RealSenseNode::publishTopics()
     // Haven't been able to figure out what magical power registerDynamicReconfigCb() holds to break auto exposure setting.
     // The suspicion is that the order of initializing/setting auto exposure and manual exposure values done by this function
     // may be setting auto exposure to something other than expected.
-    // Thus, have to ensure setupDevice(), which in turn runs fixSetAutoExposure(), runs before this function to restore order in D435s
+    // Thus, have to ensure setupDevice(), which in turn runs fixSetAutoExposure(), runs after this function to restore order in D435s
     if (_params)
     {
       _params->registerDynamicReconfigCb(this);

--- a/realsense2_camera/src/realsense_node.cpp
+++ b/realsense2_camera/src/realsense_node.cpp
@@ -1091,7 +1091,12 @@ void RealSenseNode::setupStreams()
             _enable[INFRA2])
         {
             static const char* frame_id = "depth_to_infra2_extrinsics";
-            auto ex = getRsExtrinsics(DEPTH, INFRA2);
+            // DEPTH -> INFRA2 query seems broken with librealsense ver >= 2.36.0
+            // This is a quick fix for now until Intel provides an offical fix
+            auto ex = getRsExtrinsics(INFRA2, DEPTH);
+            ex.translation[0] *= -1;
+            ex.translation[1] *= -1;
+            ex.translation[2] *= -1;
             _depth_to_other_extrinsics[INFRA2] = ex;
             _depth_to_other_extrinsics_publishers[INFRA2].publish(rsExtrinsicsToMsg(ex, frame_id));
         }


### PR DESCRIPTION
- Ensured depth -> infra2 extrinsics are filled with correct values. Beforehand it was filled with zeros for translation.
- Modified auto exposure setting logic based on hardware testing